### PR TITLE
clear-linux: update bare-metal-install xzcat command option

### DIFF
--- a/source/clear-linux/tutorials/bare-metal-install/bare-metal-install.rst
+++ b/source/clear-linux/tutorials/bare-metal-install/bare-metal-install.rst
@@ -106,14 +106,13 @@ following command:
 
 .. code-block:: console
 
-   xzcat –v clear-10980-installer.img.xz | dd of=/dev/sdb
+   xzcat clear-10980-installer.img.xz | dd of=/dev/sdb
 
 .. note::
 
    These commands only work in the directory containing the downloaded file.
 
-The decompression and copy of the image file takes some time to complete and
-the –v option for xzcat displays the progress.
+The decompression and copy of the image file takes some time to complete.
 
 Once the image has been decompressed and copied to the USB drive, you can
 remove the USB drive from the system and move it to your target system.


### PR DESCRIPTION
Removing the '-v' option from the xzcat command line due
to verbose output getting piped into the dd command causing
corruption on image creation.
Based on previous PR[1].

[1]-https://github.com/01org/clear-linux-documentation/pull/6

Signed-off-by: Simental Magana, Marcos <marcos.simental.magana@intel.com>