### PR TITLE
clear-linux: ensure user have 'man' command prior running man swupd.

### DIFF
--- a/source/clear-linux/how-to/swupd/run.rst
+++ b/source/clear-linux/how-to/swupd/run.rst
@@ -60,8 +60,11 @@ To force a manual update:
 Additional information
 ======================
 
-To see the man page listing additional swupd options, enter:
+To see the man page listing additional swupd options, install the
+`sysadmin-basic` bundle to access the `man` command and later access
+the man page:
 
    .. code-block:: console
 
+      $ sudo swupd bundle-add sysadmin-basic
       $ man swupd


### PR DESCRIPTION
Documentation recommends the user to access swupd the man page for
further details, however user may not have /usr/bin/man command
installed, so document that he/she needs to install 'sysadmin-basic'
bundle prior to actually accessing the man-page.

Signed-off-by: Simental Magana, Marcos <marcos.simental.magana@intel.com>