### PR TITLE
Change notice from important to note on the Wordpress tutorial.

### DIFF
--- a/source/clear-linux/tutorials/wordpress.rst
+++ b/source/clear-linux/tutorials/wordpress.rst
@@ -20,7 +20,7 @@ to the WordPress tutorial.
     web-server-install/web-server-install.rst
     wp-install/wp-install.rst
 
-.. important::
+.. note::
 
    This tutorial is for development and testing purposes only. Additional
    steps are required to secure production systems.


### PR DESCRIPTION
The website does not support important notices, therfore the notice had to
change to a note.

Signed-off-by: Rodrigo Caballero <rodrigo.caballero.abraham@intel.com>