### PR TITLE
gitignore: fix build directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 #Exluding from the tree the html build files
-build
+source/_build
 # ignore vi temporary files
 *.swp
 *~


### PR DESCRIPTION
Fix the build directory path in the gitignore file.

Signed-off-by: Miguel Bernal Marin <miguel.bernal.marin@linux.intel.com>