### PR TITLE
Fix instructions for openssh-server bundle doc

### DIFF
--- a/source/clear-linux/bundles/openssh-server.rst
+++ b/source/clear-linux/bundles/openssh-server.rst
@@ -19,7 +19,7 @@ the following configuration of the :abbr:`SSHD (SSH Daemon)` service file:
 
    .. code-block:: console
 
-      # mkdir /etc/systemd/system/sshd@.service.d
+      # mkdir -p /etc/systemd/system/sshd@.service.d
 
 #. Create the following file:
    :file:`/etc/systemd/system/sshd@.service.d/sftp.conf`
@@ -30,6 +30,12 @@ the following configuration of the :abbr:`SSHD (SSH Daemon)` service file:
 
       [Service]
       Environment="OPTIONS=-o Subsystem=\"sftp /usr/libexec/sftp-server\""
+
+#. Reload systemd configuration:
+
+   .. code-block:: console
+
+      # systemctl daemon-reload
 
 Congratulations! The SFTP subsystem is enabled.
 


### PR DESCRIPTION
Use "mkdir -p" to avoid failure when some part in the middle of the
path doesn't exist (this is currently the case with a freshly
installed Clear 16820).

Add instruction to reload the systemd configuration, otherwise the
OPTIONS line won't be used and the subsystem won't work.

Signed-off-by: Caio Marcelo de Oliveira Filho <caio.oliveira@intel.com>