### PR TITLE
Clear lamp server mods

### DIFF
--- a/source/clear-linux/tutorials/web-server-install/web-server-install.rst
+++ b/source/clear-linux/tutorials/web-server-install/web-server-install.rst
@@ -71,7 +71,74 @@ browser as shown in figure 1.
     Confirmation the Apache service is running.
 
 The :file:`index.html` file is located in the :file:`/usr/share/httpd/htdocs`
-directory of your host system.
+directory of your host system.  We will copy this file into a new location 
+after we modify the configuration.
+
+Change the Default Configuration and Data Directory
+===================================================
+
+|CL| is designed to be a stateless operating system which means that you will
+need to create an optional configuration file.  The default location of the
+Apache configuration file, httpd.conf, is located in the
+/etc/share/defaults/httpd directory, which can be overwritten as part of the
+stateless paradigm.  This default .conf file includes the following directives
+that allow for additional locations of configuration definitions:
+
+.. code-block:: console
+
+   # Virtual hosts
+   IncludeOptional /usr/share/defaults/httpd/conf.d/*.conf
+   IncludeOptional /usr/share/defaults/httpd/conf.modules.d/*.conf
+   IncludeOptional /etc/httpd/conf.d/*.conf
+   IncludeOptional /etc/httpd/conf.modules.d/*.conf
+
+
+For this tutorial, we will create the directory structure for /etc/httpd/conf.d
+and then create the httpd.conf file within /etc/httpd/conf.d directory and
+include the variable DocumentRoot.
+
+Using your favorite editor, copy the content listed below into the new file
+:file:`/etc/httpd/conf.d/httpd.conf`
+
+.. code-block:: console
+
+   #
+   # Set a new location for DocumentRoot
+   #
+   DocumentRoot “/var/www/html”
+   
+   #
+   # Releax access to content within /var/www/html for this tutorial
+   #
+   <Directory “/var/www/html”>
+      AllowOverride none
+      Require all granted
+   </Directory>
+
+
+Finally, let’s create the new DocumentRoot directory structure and copy the
+index.html file from /usr/share/httpd/htdocs directory to /var/www/html.
+
+.. code-block:: console
+
+   sudo mkdir –p /var/www/html
+   cd /var/www/html
+   sudo cp /usr/share/httpd/htdocs/index.html .
+
+
+To make sure that we have everything set correctly, let’s edit the new
+index.html file with your favorite editor and change the text from
+“It works” to “It works in it’s new location”.
+
+With the new configuration files in place, you will need to stop and then restart the httpd.service
+
+.. code-block:: console
+
+   sudo systemctl stop httpd.service
+   sudo systemctl start httpd.service
+
+
+Now when you go to http://localhost you should see your new screen.
 
 Installing PHP
 ==============
@@ -98,7 +165,7 @@ To enable PHP, enter the following commands:
 After restarting the Apache service, we can test our PHP installation.
 
 1. Create a file named :file:`phpinfo.php` in the
-   :file:`/usr/share/httpd/htdocs/` directory using your favorite editor.
+   :file:`/var/www/html/` directory using your favorite editor.
 
 2. Add the following line to the file:
 
@@ -279,7 +346,7 @@ our |CL| host system.
 
 .. code-block:: console
 
-   cd /usr/share/httpd/htdocs
+   cd /var/www/html
    sudo tar –xzvf ~/Downloads/phpMyAdmin-4.6.4-english.tar.gz
 
 3. To keep things simple, rename the newly created
@@ -329,7 +396,7 @@ our new database WordPress.
 
        The `Databases` tab of `phpMyAdmin`.
 
-2. Enter 'Wordpress'. in the text field below the :guilabel:`Create database`
+2. Enter 'WordPress'. in the text field below the :guilabel:`Create database`
    label.
 
 3. Pick the :guilabel:`utf8_unicode_ci` option from the collation drop-down

--- a/source/clear-linux/tutorials/wp-install/wp-install.rst
+++ b/source/clear-linux/tutorials/wp-install/wp-install.rst
@@ -54,7 +54,7 @@ We are setting up a WordPress blog which can be accessed at:
 http://<your_website>/blog
 
 To accomplish this setup, we must put the WordPress components in the
-:file:`/usr/share/httpd/htdocs/blog` directory.
+:file:`/var/www/html/blog` directory.
 
 Let us get started:
 
@@ -64,7 +64,7 @@ Let us get started:
 
    .. code-block:: console
 
-      cd /usr/share/httpd/htdocs
+      cd /var/www/html
 
 2. To download the latest version of WordPress, enter the following command:
 
@@ -72,7 +72,7 @@ Let us get started:
 
       sudo curl -O https://wordpress.org/latest.tar.gz
 
-3. To extract the all the files and directories from the downloaded file,
+3. To extract all the files and directories from the downloaded file,
    enter the following command:
 
    .. code-block:: console
@@ -96,7 +96,7 @@ Setting up WordPress
 --------------------
 
 With the WordPress components loaded into the
-:file:`/usr/share/httpd/htdocs/blog` directory, we can set everything up.
+:file:`/var/www/html/blog` directory, we can set everything up.
 
 Instead of editing the :file:`wp_config.php` file manually, we are using the
 web-based configuration tool to setup the database name and user. We created


### PR DESCRIPTION
Update the LAMP tutorial to add additional steps to customize the Apache configuration and locate the DocumentRoot in the /var/www/html directory to satisfy stateless requirements and changed all references from the /usr/share/httpd/htdocs directory to /var/www/html in both the LAMP server tutorial as well as the WordPress tutorial