### PR TITLE
Update Clear Containers docs to release 3.0

### DIFF
--- a/source/clear-containers/architecture-overview.rst
+++ b/source/clear-containers/architecture-overview.rst
@@ -10,6 +10,9 @@ gets improved and overhead gets reduced by optimizing existing code,
 removing redundant components, and implementing new techniques for
 containers with :abbr:`KVM (Kernel Virtual Machine)`.
 
+The latest release of Intel® Clear Containers is release 3.0. You can find
+detailed technical information on our `architecture overview`_ on GitHub.
+
 Version 1.0 of Clear Containers was designed as a lightweight container
 system based around `kvmtool`_'s ``lkvm``,
 :abbr:`KVM (Kernel Virtual Machine)` and Intel VT-x features; the
@@ -402,3 +405,5 @@ FAQ
 .. _Intel ARK website: http://ark.intel.com
 .. _kvmtool: https://git.kernel.org/cgit/linux/kernel/git/will/kvmtool.git/
 .. _rkt: https://coreos.com/rkt/
+.. _architecture overview:
+   https://github.com/clearcontainers/runtime/blob/master/docs/architecture/architecture.md

--- a/source/clear-containers/getting-started.rst
+++ b/source/clear-containers/getting-started.rst
@@ -8,7 +8,7 @@ the secure and fast Intel Clear Containers environment under Docker\*
 v17.05.0-ce and beyond via an :abbr:`Open Container Initiative (OCI)`
 compatible `runtime`.
 
-Visit our :ref:`architecture-overview` for detailed architectural
+Visit our `architecture overview`_ for detailed architectural
 information.
 
 Installation instructions
@@ -18,13 +18,13 @@ The primary host platform is Clear Linux\* Project for Intel® Architecture.
 For instructions on installing Docker and Clear Containers under Clear Linux,
 please refer to instructions from the runtime source tree:
 
-	•	https://github.com/01org/cc-oci-runtime/wiki/Installation
+	•	https://github.com/clearcontainers/runtime/wiki/Installation
 
 If you have any feedback, questions, or would like to participate and
 contribute, then  please consult the contact details (mailing list, IRC etc.)
 in the document at:
 
-- https://github.com/01org/cc-oci-runtime/blob/master/CONTRIBUTING.md
+- https://github.com/clearcontainers/runtime/CONTRIBUTING.md
 
 Source Code
 ===========
@@ -32,6 +32,7 @@ Source Code
 The source code for the Clear Containers 2.0 runtime and corresponding
 qemu-lite are publicly hosted on github:
 
-- https://github.com/01org/cc-oci-runtime
-- https://github.com/01org/qemu-lite
+- https://github.com/clearcontainers/runtime/
 
+.. _architecture overview:
+   https://github.com/clearcontainers/runtime/blob/master/docs/architecture/architecture.md


### PR DESCRIPTION
Updates the content to link to the information in the Intel Clear Containers GitHub.
Signed-off-by: Rodrigo Caballero <rodrigo.caballero.abraham@intel.com>